### PR TITLE
Fix Electron launch failure and add a self-healing preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ e2e                 Playwright end-to-end flows (web + desktop)
 | Command | What |
 | --- | --- |
 | `pnpm dev` | mock + backend + web, wired together (`--no-web` for API only) |
-| `pnpm doctor` | preflight: Node, deps, key shape |
+| `pnpm run doctor` | preflight: Node, deps, key shape, Electron binary (needs `run` — `pnpm doctor` is a pnpm built-in) |
+| `pnpm fix:electron` | re-install Electron's binary if `pnpm desktop` says it "failed to install correctly" |
 | `pnpm test` | every unit + integration suite (offline, no spend) |
 | `pnpm typecheck` · `pnpm lint` · `pnpm format` | strict static checks |
 | `pnpm e2e` | Playwright: web + desktop journeys vs the mock |

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -64,8 +64,9 @@ This is enforced in code (`apps/backend/src/config.ts`) and proven three ways:
 `config.test.ts` (12 cases pinning every branch), `bootstrap.test.ts` (boots
 the real in-process server from an EMPTY env and runs a full flow), and
 `e2e/bootstrap-smoke.mjs` (spawns the actual `main.ts` + mock CLI with no key
-and drives login→provision→run→succeeded over real HTTP). `pnpm doctor` is a
-preflight check; `pnpm dev` is the one-command runner.
+and drives login→provision→run→succeeded over real HTTP). `pnpm run doctor` is a
+preflight check (the `run` is required — `pnpm doctor` is a pnpm built-in that
+shadows the script); `pnpm dev` is the one-command runner.
 
 ## Verification status
 

--- a/e2e/tests/desktop.spec.ts
+++ b/e2e/tests/desktop.spec.ts
@@ -84,18 +84,26 @@ test('desktop shell boots, exposes window.cowork, and offers the local target', 
     // Sign in inside the desktop shell.
     await page.getByLabel(/email/i).fill(`desktop-${Date.now()}@example.com`);
     await page.getByRole('button', { name: /sign in/i }).click();
-    await expect(page.getByRole('heading', { name: /delegate a task/i })).toBeVisible();
+    // See web.spec.ts: there is no "Delegate a task" heading; the signed-in
+    // shell is what proves the session. On desktop the composer DOES render
+    // without a cloud machine, because "This computer" is always an option.
+    await expect(page.getByRole('button', { name: /sign out/i })).toBeVisible();
 
-    // The local screen target is first-class on desktop.
-    const machineSelect = page.getByRole('combobox');
-    await expect(machineSelect.locator('option', { hasText: /this computer/i })).toHaveCount(1);
+    // The local screen target is first-class on desktop. The composer's machine
+    // picker is an in-house combobox (a button that opens a role="listbox"
+    // popover), not a native <select>, so selectOption() does not apply and the
+    // options exist only while the popover is open — open it, assert, click.
+    const machineSelect = page.getByRole('combobox', { name: 'Machine' });
+    await machineSelect.click();
+    const localOption = page.getByRole('option', { name: /this computer/i });
+    await expect(localOption).toHaveCount(1);
+    await localOption.click();
 
     // Selecting it and submitting surfaces the local-control warning in the
     // confirm dialog — then we cancel instead of starting (real input safety).
     await page.getByLabel(/task/i).fill('organize my downloads folder');
-    await machineSelect.selectOption({ label: 'This computer (local screen)' });
-    await page.getByRole('button', { name: /delegate|run task|start|submit/i }).click();
-    const confirm = page.getByRole('dialog', { name: /confirm cost/i });
+    await page.getByRole('button', { name: 'Send' }).click();
+    const confirm = page.getByRole('dialog', { name: /ready to start/i });
     await expect(confirm).toContainText(/your own mouse and keyboard/i);
     await confirm.getByRole('button', { name: /^cancel$/i }).click();
     await expect(confirm).toBeHidden();

--- a/e2e/tests/web.spec.ts
+++ b/e2e/tests/web.spec.ts
@@ -32,7 +32,25 @@ async function login(page: Page): Promise<void> {
   await page.goto('/login');
   await page.getByLabel(/email/i).fill(email);
   await page.getByRole('button', { name: /sign in/i }).click();
-  await expect(page.getByRole('heading', { name: /delegate a task/i })).toBeVisible();
+  // Assert the authenticated shell, not the composer: the Delegate page has no
+  // "Delegate a task" heading (it is a logo + caption + composer), and with no
+  // machine yet it renders the "No machine to run on" empty state instead of
+  // the composer at all. "Sign out" is what actually proves a session exists.
+  await expect(page.getByRole('button', { name: /sign out/i })).toBeVisible();
+}
+
+/**
+ * Pick a target in the composer's machine selector.
+ *
+ * It is an in-house combobox — a `<button role="combobox">` that opens a
+ * `<ul role="listbox">` popover — not a native `<select>`, so `selectOption()`
+ * throws "Element is not a <select> element". The options only exist in the DOM
+ * while the popover is open, so open it first, then click. Scoped by accessible
+ * name because a second "Screen" combobox appears once a local target is chosen.
+ */
+async function selectMachine(page: Page, name?: RegExp): Promise<void> {
+  await page.getByRole('combobox', { name: 'Machine' }).click();
+  await (name ? page.getByRole('option', { name }) : page.getByRole('option').first()).click();
 }
 
 async function ensureMachine(page: Page): Promise<void> {
@@ -64,13 +82,19 @@ test.describe('full delegate → watch → approve → complete journey', () => 
     // Delegate a task that pauses for a human.
     await page.getByRole('link', { name: /delegate/i }).click();
     await page.getByLabel(/task/i).fill('Sort the inbox NEEDS_HUMAN then archive the rest');
-    await page.getByRole('combobox').selectOption({ index: 1 }); // first real machine
-    await page.getByRole('button', { name: /delegate|run task|start|submit/i }).click();
+    await selectMachine(page); // first (and only) provisioned machine
+    await page.getByRole('button', { name: 'Send' }).click();
 
-    // Explicit cost confirmation before anything billable.
-    const confirm = page.getByRole('dialog', { name: /confirm cost/i });
+    // Explicit confirmation before anything billable. The dialog deliberately
+    // shows no dollar figure any more (c1a7373, "friendlier run-confirm with a
+    // settable step limit, no cost shown"), so asserting "$1.25" here would be
+    // pinning UI that was removed on purpose. What the gate still guarantees is
+    // what we check: it interrupts the flow, and the worst case is bounded by a
+    // visible, settable step limit. The server-side cost handshake is enforced
+    // independently — the budget-safety test below covers that.
+    const confirm = page.getByRole('dialog', { name: /ready to start/i });
     await expect(confirm).toBeVisible();
-    await expect(confirm).toContainText('$1.25'); // 25 steps × $0.05 worst case
+    await expect(confirm.getByLabel(/maximum steps/i)).toHaveValue('25');
     await confirm.getByRole('button', { name: /start run/i }).click();
 
     // Live run view: timeline events stream in.
@@ -79,7 +103,7 @@ test.describe('full delegate → watch → approve → complete journey', () => 
     await expect(page.getByText(/step \d+ completed/i).first()).toBeVisible({ timeout: 20_000 });
 
     // Live screen frames from the machine appear.
-    await expect(page.getByAltText(/remote machine screen/i)).toHaveAttribute(
+    await expect(page.getByAltText(/machine screen/i)).toHaveAttribute(
       'src',
       /data:image\/png;base64,/,
       { timeout: 20_000 },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "desktop": "node scripts/dev.mjs --desktop",
     "dev": "node scripts/dev.mjs",
     "doctor": "node scripts/doctor.mjs",
+    "fix:electron": "node scripts/ensure-electron.mjs",
     "build": "turbo run build",
     "test": "turbo run test",
     "test:coverage": "turbo run test:coverage",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -20,6 +20,7 @@ import { spawn, execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { ensureElectron } from './ensure-electron.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const isWin = process.platform === 'win32';
@@ -212,6 +213,22 @@ if (!usesMock) {
 }
 
 void (async () => {
+  // Electron's real binary lives outside the lockfile's view, so `pnpm install`
+  // can report "Already up to date" while `electron .` is broken. Verify (and
+  // self-repair) BEFORE anything else: otherwise backend + web boot, the
+  // backend talks to Coasty on a possibly LIVE key, and only then does the
+  // desktop child die with "Electron failed to install correctly".
+  if (wantDesktop && !ensureElectron()) {
+    process.stderr.write(
+      '\n[desktop] Electron is not runnable — stopping before the stack starts.\n' +
+        '[desktop] `pnpm dev` (web only, no local screen control) still works.\n',
+    );
+    // Return rather than process.exit() so the message above actually drains;
+    // nothing has been spawned yet, so there is nothing to tear down.
+    process.exitCode = 1;
+    return;
+  }
+
   // Reclaim the ports we're about to bind so a leftover process from a previous
   // run starts cleanly instead of failing (web's strictPort makes a held :5173
   // fatal). Only ports this run will actually use are touched.

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -4,11 +4,16 @@
  * with nothing but (optionally) a Coasty key. Prints a clear, actionable
  * report and exits non-zero if anything would block `pnpm dev`.
  *
- *   pnpm doctor
+ *   pnpm run doctor
+ *
+ * The `run` is required: `doctor` is also a built-in pnpm command, and bare
+ * `pnpm doctor` runs pnpm's own checker instead of this script (silently — it
+ * exits 0 and prints nothing but a config warning).
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { inspectElectron } from './ensure-electron.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const OK = '\x1b[32m✓\x1b[0m';
@@ -79,11 +84,28 @@ if (existsSync(join(ROOT, 'node_modules', '.pnpm'))) {
   blocking++;
 }
 
+// Electron's binary is fetched by a postinstall and lives outside the lockfile,
+// so it can be missing while pnpm reports "Already up to date". Only `pnpm
+// desktop` needs it, so this warns rather than blocks.
+const electron = inspectElectron();
+if (electron.ok) {
+  line(OK, `${electron.detail} — \`pnpm desktop\` can launch`);
+} else if (electron.status === 'unsupported-platform') {
+  line(WARN, `${electron.detail} — \`pnpm desktop\` is unavailable here; \`pnpm dev\` still works`);
+} else {
+  line(
+    WARN,
+    `Electron not runnable (${electron.detail}) — run \`pnpm fix:electron\`; \`pnpm dev\` still works`,
+  );
+}
+
 console.log('');
 if (blocking === 0) {
   console.log('Ready. Run `pnpm dev` to start everything (Ctrl+C stops it).');
-  process.exit(0);
 } else {
-  console.log(`${blocking} blocking issue(s) above. Fix them, then re-run \`pnpm doctor\`.`);
-  process.exit(1);
+  console.log(`${blocking} blocking issue(s) above. Fix them, then re-run \`pnpm run doctor\`.`);
 }
+// Set the code and let Node exit naturally. `process.exit()` can tear the
+// process down before stdout drains, since writes to a pipe (as opposed to a
+// TTY) are asynchronous — which would truncate the report above.
+process.exitCode = blocking === 0 ? 0 : 1;

--- a/scripts/ensure-electron.mjs
+++ b/scripts/ensure-electron.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * Electron binary preflight + self-repair.
+ *
+ *   pnpm fix:electron
+ *
+ * The `electron` npm package is a ~1 MB stub; the real 100–200 MB runtime is
+ * fetched by its own `postinstall` (install.js) and unzipped into the package's
+ * `dist/`. That output is invisible to the lockfile, so it can go missing while
+ * pnpm still considers the tree fully installed:
+ *
+ *   - pnpm 10 blocks postinstall scripts unless the package is listed under
+ *     `onlyBuiltDependencies` (it is, in pnpm-workspace.yaml) — drop that entry
+ *     and electron links but never builds;
+ *   - an interrupted/offline install, a pruned store, or a re-link of the
+ *     virtual store can leave the package present but unbuilt;
+ *   - antivirus, a disk-cleanup tool, or a file-sync client (OneDrive, Dropbox)
+ *     can delete `dist/` after the fact — it is a folder of large .exe files.
+ *
+ * In every case `pnpm install` then says "Already up to date" while `electron .`
+ * dies with:
+ *
+ *   Error: Electron failed to install correctly, please delete
+ *   node_modules/electron and try installing again
+ *
+ * ...because index.js only throws when `path.txt` is absent. Re-running
+ * install.js repairs it, and is usually cheap: the downloaded zip is kept in the
+ * @electron/get cache, so a repair is just a local unzip.
+ *
+ * Used by `pnpm desktop` (checks + auto-repairs before booting the stack) and
+ * `pnpm run doctor` (reports only). No dependencies; Windows + macOS + Linux.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Executable path *inside* dist/, per platform. Mirrors electron's install.js. */
+function platformExecutable(platform = process.env.npm_config_platform || process.platform) {
+  switch (platform) {
+    case 'mas':
+    case 'darwin':
+      return 'Electron.app/Contents/MacOS/Electron';
+    case 'freebsd':
+    case 'openbsd':
+    case 'linux':
+      return 'electron';
+    case 'win32':
+      return 'electron.exe';
+    default:
+      return null; // Electron publishes no build for this platform
+  }
+}
+
+/**
+ * Directory of the installed `electron` package, or null when it isn't there.
+ * Resolved from apps/desktop because that is the only workspace package that
+ * depends on it — with pnpm's isolated node_modules it is deliberately NOT
+ * resolvable from the repo root.
+ */
+export function electronPackageDir() {
+  try {
+    // `electron/package.json` (not `electron`) so resolution never executes
+    // index.js — which throws by design when the binary is missing.
+    return dirname(
+      createRequire(join(ROOT, 'apps', 'desktop', 'package.json')).resolve('electron/package.json'),
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is the Electron runtime actually on disk, and does it match the package?
+ * Returns `{ ok, status, detail, dir, version }` where status is one of
+ * 'ok' | 'not-installed' | 'unsupported-platform' | 'missing-binary' | 'version-mismatch'.
+ */
+export function inspectElectron() {
+  const dir = electronPackageDir();
+  if (!dir) {
+    return {
+      ok: false,
+      status: 'not-installed',
+      detail: 'the `electron` package is not installed — run `pnpm install`',
+      dir: null,
+      version: null,
+    };
+  }
+
+  let version = null;
+  try {
+    version = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')).version ?? null;
+  } catch {
+    /* unreadable package.json — treated as "unknown version" below */
+  }
+
+  // npm_config_platform lets a caller cross-target; report whichever platform
+  // the decision was actually made for, not just the host's.
+  const targetPlatform = process.env.npm_config_platform || process.platform;
+  const exe = platformExecutable(targetPlatform);
+  if (!exe) {
+    return {
+      ok: false,
+      status: 'unsupported-platform',
+      detail: `Electron publishes no build for platform "${targetPlatform}"`,
+      dir,
+      version,
+    };
+  }
+
+  // An explicit override means the caller manages the runtime themselves; don't
+  // second-guess it, just confirm something is really there.
+  const override = process.env.ELECTRON_OVERRIDE_DIST_PATH;
+  if (override) {
+    const target = join(override, exe);
+    return existsSync(target)
+      ? {
+          ok: true,
+          status: 'ok',
+          detail: `using ELECTRON_OVERRIDE_DIST_PATH (${target})`,
+          dir,
+          version,
+        }
+      : {
+          ok: false,
+          status: 'missing-binary',
+          detail: `ELECTRON_OVERRIDE_DIST_PATH is set but ${target} does not exist`,
+          dir,
+          version,
+        };
+  }
+
+  // index.js needs path.txt; the launcher needs the executable. Both or bust.
+  if (!existsSync(join(dir, 'path.txt')) || !existsSync(join(dir, 'dist', exe))) {
+    return {
+      ok: false,
+      status: 'missing-binary',
+      detail: `${join(dir, 'dist', exe)} is missing — electron's postinstall never produced it (or it was deleted)`,
+      dir,
+      version,
+    };
+  }
+
+  // A dist/ left behind by a *different* Electron version is just as broken;
+  // this is the usual state right after bumping the electron dependency.
+  let onDisk = null;
+  try {
+    onDisk = readFileSync(join(dir, 'dist', 'version'), 'utf8')
+      .trim()
+      .replace(/^v/, '');
+  } catch {
+    /* no version file — fall through and trust the executable */
+  }
+  if (version && onDisk && onDisk !== version) {
+    return {
+      ok: false,
+      status: 'version-mismatch',
+      detail: `dist/ holds Electron ${onDisk} but the installed package is ${version}`,
+      dir,
+      version,
+    };
+  }
+
+  return {
+    ok: true,
+    status: 'ok',
+    detail: `Electron ${version ?? 'unknown'} binary present`,
+    dir,
+    version,
+  };
+}
+
+/** Re-run electron's own postinstall. Cheap when the zip is already cached. */
+function runRepair(dir, log) {
+  const env = { ...process.env };
+  // install.js exits 0 immediately when this is set, which would turn the
+  // repair into a silent no-op. Ignore it here (and say so).
+  delete env.ELECTRON_SKIP_BINARY_DOWNLOAD;
+  log("    running electron's postinstall (re-uses the cached download when present)…");
+  const r = spawnSync(process.execPath, [join(dir, 'install.js')], {
+    cwd: dir,
+    env,
+    stdio: 'inherit',
+  });
+  return r.status === 0;
+}
+
+function manualSteps(err) {
+  err('    Fix it manually, in order:');
+  err('      1) pnpm fix:electron            (this script, run on its own)');
+  err('      2) pnpm -r rebuild electron     (pnpm re-runs the postinstall)');
+  err('      3) pnpm install --force         (re-links + rebuilds the whole tree)');
+  err(
+    '      4) offline or behind a proxy? set HTTPS_PROXY, or ELECTRON_MIRROR for an internal mirror',
+  );
+  err('      5) check that `electron` is still listed under onlyBuiltDependencies in');
+  err('         pnpm-workspace.yaml — pnpm 10 blocks postinstall scripts without it');
+}
+
+/**
+ * Verify Electron is runnable, attempting one automatic repair when it is not.
+ * Returns true once the binary is ready.
+ */
+export function ensureElectron({
+  repair = true,
+  log = (m) => process.stdout.write(`${m}\n`),
+  err = (m) => process.stderr.write(`${m}\n`),
+} = {}) {
+  let state = inspectElectron();
+  if (state.ok) return true;
+
+  // Nothing a repair can do about these two.
+  if (state.status === 'not-installed' || state.status === 'unsupported-platform') {
+    err(`  ✗ Electron unavailable — ${state.detail}`);
+    return false;
+  }
+  if (!repair) {
+    err(`  ✗ Electron unavailable — ${state.detail}`);
+    manualSteps(err);
+    return false;
+  }
+
+  err(`  ⚠ Electron is installed but not runnable — ${state.detail}`);
+  if (process.env.ELECTRON_SKIP_BINARY_DOWNLOAD) {
+    log('    note: ELECTRON_SKIP_BINARY_DOWNLOAD is set; ignoring it so the repair can run');
+  }
+
+  if (!runRepair(state.dir, log)) {
+    err('  ✗ automatic repair failed.');
+    manualSteps(err);
+    return false;
+  }
+
+  state = inspectElectron();
+  if (!state.ok) {
+    err(`  ✗ still not runnable after the repair — ${state.detail}`);
+    manualSteps(err);
+    return false;
+  }
+  log(`  ✓ Electron ${state.version} repaired — continuing`);
+  return true;
+}
+
+// Standalone: `node scripts/ensure-electron.mjs` / `pnpm fix:electron`.
+const self = fileURLToPath(import.meta.url);
+const invoked = process.argv[1] ? resolve(process.argv[1]) : '';
+const sameFile =
+  process.platform === 'win32' ? invoked.toLowerCase() === self.toLowerCase() : invoked === self;
+if (sameFile) {
+  const state = inspectElectron();
+  // `process.exitCode`, never `process.exit()` — stdout is async when it's a
+  // pipe (`pnpm fix:electron`), and exiting outright can swallow the report.
+  if (state.ok) {
+    console.log(`  ✓ ${state.detail}`);
+    process.exitCode = 0;
+  } else {
+    process.exitCode = ensureElectron() ? 0 : 1;
+  }
+}


### PR DESCRIPTION
## The bug

`pnpm desktop` dies with:

```
Error: Electron failed to install correctly, please delete node_modules/electron and try installing again
```

...while `pnpm install` cheerfully reports **"Already up to date"**.

Electron ships as a ~1 MB stub; the real ~190 MB runtime is fetched by its own `postinstall` and unzipped into the package's `dist/`. That output is **invisible to the lockfile**, so once it goes missing — a re-link of the virtual store, a pruned store, antivirus, or a file-sync client eating a folder of large `.exe` files — pnpm still considers the tree fully installed and never repairs it.

Reproduced directly: with `dist/` and `path.txt` removed, `pnpm install` finishes in 900 ms saying "Already up to date" and the app still cannot start. The download was never the problem — the cached zip was present the whole time; only the extracted output was gone.

`onlyBuiltDependencies` already lists `electron`, so pnpm 10's script-blocking was **not** the cause here — but it's a neighbouring failure mode with identical symptoms, so the repair covers it too.

## What changed

- **`scripts/ensure-electron.mjs`** (new) — verifies `path.txt` + the platform executable exist and that `dist/version` matches the installed package (which also catches a stale `dist/` after an electron bump, a bug you'd otherwise hit on upgrade). Repairs by re-running electron's own postinstall, which is cheap because the download is cached. Honours `ELECTRON_OVERRIDE_DIST_PATH`, and ignores `ELECTRON_SKIP_BINARY_DOWNLOAD` during repair (it would otherwise make the repair a silent no-op).
- **`scripts/dev.mjs`** — checks *before* booting anything. Previously backend + web started, the backend connected to Coasty **on a possibly live key**, and only then did the desktop child die. Now it fails in under a second with nothing spawned.
- **`scripts/doctor.mjs`** — reports Electron status as a warning, not a blocker, since `pnpm dev` works fine without it.
- **`pnpm fix:electron`** — standalone repair command.

## Two latent bugs found on the way

1. **`pnpm doctor` never ran this repo's script.** `doctor` is a *built-in pnpm command*, so bare `pnpm doctor` runs pnpm's own checker — exits 0, prints nothing but a config warning. The preflight has been silently unreachable. It needs `pnpm run doctor`; README/SUMMARY updated.
2. **`process.exit()` straight after `console.log`** in `doctor.mjs` can tear the process down before stdout drains when stdout is a pipe. Switched to `process.exitCode`.

## Verification

Broke it the exact reported way (removed `dist/` + `path.txt`), confirmed the repro, confirmed `pnpm install` does *not* fix it, then confirmed `pnpm fix:electron` repairs it and `electron --version` returns `v33.4.11`. Also exercised the `dev.mjs` abort path with no network and no Coasty calls. `pnpm lint` and `pnpm format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
