### PR TITLE
fix(test): stop the "zero-config" bootstrap test hitting the LIVE Coasty API

### DIFF
--- a/apps/backend/test/bootstrap.test.ts
+++ b/apps/backend/test/bootstrap.test.ts
@@ -31,12 +31,28 @@ beforeAll(async () => {
   const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
   // The whole point: NOTHING configured. loadConfig must produce a working
   // demo setup that targets the mock on 4010.
-  const config = loadConfig({});
+  //
+  // COWORK_DB_PATH is the ONE thing pinned, and it is not a cheat: the default
+  // (./data/cowork.sqlite) is the DEVELOPER'S REAL DATABASE. A runtime Coasty
+  // key persisted there outranks demo mode in resolveBootCredentials AND flips
+  // the base URL to live coasty.ai — so on any machine where someone has saved
+  // a key through the UI, this "zero-config demo" test silently provisioned
+  // REAL, BILLABLE machines against their account. Every other backend test
+  // already isolates the database exactly this way.
+  const config = loadConfig({ COWORK_DB_PATH: ':memory:' });
   warn.mockRestore();
   expect(config.demoMode).toBe(true);
   expect(config.coastyBaseUrl).toBe(MOCK_BASE_URL);
 
   built = buildServer({ config });
+  // Assert what the Coasty client will ACTUALLY use, not just what loadConfig
+  // returned. The two assertions above both passed while the shared client was
+  // pointed at live coasty.ai with a billable key, because resolveBootCredentials
+  // overrides the config's base URL when it finds a persisted runtime key. This
+  // is the assertion that would have caught it.
+  expect(built.credentials.source).toBe('demo');
+  expect(built.credentials.demoMode).toBe(true);
+  expect(built.credentials.baseUrl).toBe(MOCK_BASE_URL);
   await built.app.listen({ port: 0, host: '127.0.0.1' });
   backendUrl = `http://127.0.0.1:${(built.app.server.address() as { port: number }).port}`;
 });


### PR DESCRIPTION
> **Spend-safety fix — worth landing ahead of anything else in flight.**

## What is wrong

`apps/backend/test/bootstrap.test.ts` describes itself as the zero-config proof — *"build the backend from a COMPLETELY empty environment"*. It was not hermetic.

It was the **only** backend test calling `loadConfig({})` with the default `dbPath`, which resolves to `./data/cowork.sqlite` — the developer's real database. [`resolveBootCredentials`](../blob/main/apps/backend/src/routes/config.ts#L60) prefers a Coasty key persisted there over demo mode, **and** swaps the base URL for live `coasty.ai`:

```
config.demoMode      : true                      <- the test asserted this
config.coastyBaseUrl : http://127.0.0.1:4010/v1  <- and this
credentials.source   : runtime
credentials.baseUrl  : https://coasty.ai/v1      <- what the client actually used
key family           : LIVE (BILLABLE)
```

Both assertions the test made passed while the shared client was pointed at production.

**Consequence:** on any machine where someone has saved a key through the Settings UI, `pnpm test` silently provisioned **real, billable machines** on their Coasty account — one per run. The visible symptom was the machine-id assertion failing with a UUID (what live Coasty returns) instead of `mch_test_*` (what the sandbox returns), which reads like a mock bug rather than a live call.

CI was unaffected: a fresh runner has no `data/cowork.sqlite`, so demo mode resolved correctly there. This only bites local developers — which is also why it went unnoticed.

## The fix

- **Pin `COWORK_DB_PATH: ':memory:'`.** Not a cheat on "empty environment": the persisted database is developer *state*, not configuration, and every other backend test already isolates it this way.
- **Assert `built.credentials`** — what the Coasty client actually resolves — instead of trusting `config` alone. That is the assertion that would have caught this, and it now guards the whole class of regression.

## Verification

- `test/bootstrap.test.ts` drops from **~2100ms to ~89ms** — it is no longer making network round-trips to coasty.ai.
- Backend suite **120/120**; lint and format clean.

## Not a key exposure

The persisted key lives under `apps/backend/data/`, which is gitignored and has never been committed. Confirmed with `git log --all -- 'apps/backend/data/*.sqlite'` (empty). No credential ever reached the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
