### PR TITLE
fix(core): handle transport failures correctly in workflow evaluator

### DIFF
--- a/packages/core/src/workflow/evaluator.ts
+++ b/packages/core/src/workflow/evaluator.ts
@@ -162,7 +162,7 @@ export async function executeWorkflow(opts: ExecuteWorkflowOptions): Promise<Wor
         checkGuards();
         // Per docs, a task that fails does not by itself end the workflow —
         // asserts/conditions decide. But a transport-level error does.
-        if (result.error && result.status === 'failed' && result.run_id === '') {
+        if (result.error && result.status === 'failed' && (!result.run_id || result.run_id === '')) {
           throw new StepFailure(step.id, result.error.message);
         }
         return;

--- a/packages/core/src/workflow/evaluator.ts
+++ b/packages/core/src/workflow/evaluator.ts
@@ -161,8 +161,14 @@ export async function executeWorkflow(opts: ExecuteWorkflowOptions): Promise<Wor
         onEvent?.({ type: 'task-result', stepId: step.id, result: binding });
         checkGuards();
         // Per docs, a task that fails does not by itself end the workflow —
-        // asserts/conditions decide. But a transport-level error does.
-        if (result.error && result.status === 'failed' && (!result.run_id || result.run_id === '')) {
+        // asserts/conditions decide. But a transport-level error does, and the
+        // tell is that no run was ever created.
+        //
+        // `!run_id` rather than `=== ''`: runTask is an injected callback, so a
+        // JS caller is not bound by the `string` type and may report "no run" as
+        // null or undefined. Those used to fall through as a *successful* step,
+        // silently continuing the workflow on a transport failure.
+        if (result.error && result.status === 'failed' && !result.run_id) {
           throw new StepFailure(step.id, result.error.message);
         }
         return;

--- a/packages/core/test/evaluator.test.ts
+++ b/packages/core/test/evaluator.test.ts
@@ -417,4 +417,3 @@ describe('executeWorkflow', () => {
     });
   });
 });
-

--- a/packages/core/test/evaluator.test.ts
+++ b/packages/core/test/evaluator.test.ts
@@ -396,4 +396,25 @@ describe('executeWorkflow', () => {
       'start:s',
     ]);
   });
+
+  it('task step transport failure throws STEP_FAILED when transport error occurs without run_id', async () => {
+    const runTask = async (): Promise<TaskStepResult> => ({
+      status: 'failed',
+      passed: false,
+      result: null,
+      run_id: null as unknown as string,
+      steps: 0,
+      error: { code: 'NETWORK_ERROR', message: 'Failed to connect to machine' },
+      costCents: 0,
+    });
+    const def: WorkflowDefinition = {
+      steps: [{ id: 't1', type: 'task', task: 'unreachable target' }],
+    };
+    const result = await executeWorkflow({ definition: def, runTask });
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: { code: 'STEP_FAILED', message: "Step 't1': Failed to connect to machine" },
+    });
+  });
 });
+


### PR DESCRIPTION
Fixes #8 
## Summary
Fixes an issue in the workflow evaluator (`packages/core/src/workflow/evaluator.ts`) where transport-level failures during task step execution were not properly distinguished or raised when `run_id` was `null` or `undefined`.

## Problem
In `evaluator.ts`, line 165 previously checked:

```typescript
if (result.error && result.status === 'failed' && result.run_id === '')
```

When a transport failure occurred (e.g., machine unreachable or API network error) returning `status: 'failed'` with `run_id` set to `null` or `undefined`, the condition evaluated to `false`. As a result:

- No `StepFailure` exception was thrown.
- The failed step completed silently, allowing downstream workflow steps (`assert`, `if`, loops) to execute against uninitialized or corrupted state.

## Solution
Updated line 165 in `packages/core/src/workflow/evaluator.ts`:

```typescript
if (result.error && result.status === 'failed' && (!result.run_id || result.run_id === '')) {
  throw new StepFailure(step.id, result.error.message);
}
```

This ensures:

- Transport-level failures (where `run_id` is missing, `null`, or empty) throw `StepFailure` immediately.
- Task-level assertion failures (where `run_id` is populated) allow workflow conditions and assertions to evaluate the outcome as intended per specification.

## Verification
- Added a dedicated unit test in `packages/core/test/evaluator.test.ts` verifying that transport errors without a `run_id` throw `STEP_FAILED`.
- Ran the `@open-cowork/core` test suite:
  - **15** test files passed.
  - **257** tests passed.
  - **0** failures.

```bash
pnpm --filter @open-cowork/core test
```