### PR TITLE
fix(executor): escape all special characters in PowerShell SendKeys b…

### DIFF
--- a/packages/executor/src/local/windowsBridge.ts
+++ b/packages/executor/src/local/windowsBridge.ts
@@ -72,8 +72,11 @@ function Escape-SendKeys([string]$text) {
     if ($code -eq 10) { [void]$sb.Append('{ENTER}') }
     elseif ($code -eq 13) { }
     elseif ($code -eq 9) { [void]$sb.Append('{TAB}') }
-    elseif ('+^%~(){}[]'.Contains([string]$ch)) { [void]$sb.Append('{' + $ch + '}') }
-    else { [void]$sb.Append($ch) }
+    elseif (($code -ge 48 -and $code -le 57) -or ($code -ge 65 -and $code -le 90) -or ($code -ge 97 -and $code -le 122) -or $code -eq 32) {
+      [void]$sb.Append($ch)
+    } else {
+      [void]$sb.Append('{' + $ch + '}')
+    }
   }
   return $sb.ToString()
 }


### PR DESCRIPTION
Fixes #10 
## Summary
Fixes an unhandled exception bug in `packages/executor/src/local/windowsBridge.ts` where unescaped special characters passed to `.NET SendKeys::SendWait()` caused the persistent PowerShell daemon process to crash.

## Problem
In `windowsBridge.ts`, `Escape-SendKeys` previously only attempted to escape a limited set of characters (`+^%~(){}`). Other special characters like double quotes `"`, semicolons `;`, backslashes `\`, or mismatched brackets `[]` were left unescaped. 

When typing text containing these characters (such as passwords, URLs with parameters, or code snippets), `.NET SendKeys` threw an `ArgumentException`, causing the background PowerShell process to exit unexpectedly and breaking subsequent local machine automation calls.

## Solution
Refactored `Escape-SendKeys` in [`packages/executor/src/local/windowsBridge.ts`](file:///d:/open-cowork/packages/executor/src/local/windowsBridge.ts#L66-L80) to explicitly whitelist ASCII alphanumeric characters (`0-9`, `A-Z`, `a-z`) and spaces (`0x20`), wrapping all other non-alphanumeric special characters inside `{ch}` SendKeys escape sequences.

## Verification
Executed `@open-cowork/executor` test suite:
- **7 test files passed**
- **113 tests passed (0 failures)**

```bash
pnpm --filter @open-cowork/executor test