### PR TITLE
fix(backend): accept cua_version v5 in the local-session proxy

### DIFF
--- a/apps/backend/src/routes/machines.ts
+++ b/apps/backend/src/routes/machines.ts
@@ -12,6 +12,7 @@ import type { FastifyInstance } from 'fastify';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import {
+  CUA_VERSIONS,
   machineRuntimeCentsPerHour,
   PRICING,
   type CoastyClient,
@@ -156,7 +157,7 @@ export function registerMachineRoutes(app: FastifyInstance, deps: MachineRouteDe
 
   // ── inference proxy (desktop local agent loop; key stays server-side) ──────
   const sessionSchema = z.object({
-    cuaVersion: z.enum(['v1', 'v3', 'v4']).default('v3'),
+    cuaVersion: z.enum(CUA_VERSIONS).default('v3'),
     screenWidth: z.number().int().min(320).max(3840).default(1920),
     screenHeight: z.number().int().min(240).max(2160).default(1080),
     instructions: z.string().max(16000).optional(),

--- a/apps/backend/test/integration.test.ts
+++ b/apps/backend/test/integration.test.ts
@@ -567,4 +567,18 @@ describe('inference proxy (desktop local loop)', () => {
     });
     expect(deleteRes.status).toBe(200);
   });
+
+  // Regression test for a schema-drift bug: this endpoint's cua_version enum
+  // was hand-typed and predated the v5 engine, so it 400'd on the very
+  // version every other endpoint in the app accepts (and tasks default to).
+  it('accepts every documented cua_version, including v5', async () => {
+    h = await startHarness();
+    for (const cuaVersion of ['v1', 'v3', 'v4', 'v5']) {
+      const res = await h.api('/api/proxy/sessions', {
+        method: 'POST',
+        body: JSON.stringify({ cuaVersion, screenWidth: 1280, screenHeight: 720 }),
+      });
+      expect(res.status).toBe(200);
+    }
+  });
 });


### PR DESCRIPTION
Fixes #12

## Summary

Fixes a schema-drift bug in `apps/backend/src/routes/machines.ts` where the local-session inference proxy (`/api/proxy/sessions`) rejected `cua_version: "v5"` — a valid engine version accepted, and even defaulted to, by every other endpoint in the app.

## Problem

`sessionSchema.cuaVersion` was validated against a hand-typed enum:

```typescript
cuaVersion: z.enum(['v1', 'v3', 'v4']).default('v3'),
```

This predates the v5 engine. `DECISIONS.md` (written against the 2026-06-11 docs snapshot) documents the old lineup as `v1|v3|v4`; when v5 shipped upstream and became the default, `apps/backend/src/routes/runs.ts` was updated to import the shared `CUA_VERSIONS` constant from `@open-cowork/core`, but `machines.ts`'s local-session schema was missed in that pass.

Effect: `POST /api/proxy/sessions` with `cuaVersion: "v5"` returned a 400 (`Invalid enum value. Expected 'v1' | 'v3' | 'v4', received 'v5'`), while the identical value worked fine on `/api/runs` and `/api/tasks` (which defaults to v5).

## Solution

`apps/backend/src/routes/machines.ts`:

```diff
- cuaVersion: z.enum(['v1', 'v3', 'v4']).default('v3'),
+ cuaVersion: z.enum(CUA_VERSIONS).default('v3'),
```

Reuses the same shared constant `runs.ts` already relies on, so the two schemas can't drift apart again.

## Verification

* Added a regression test (`apps/backend/test/integration.test.ts`) that hits `/api/proxy/sessions` with every documented `cuaVersion` (v1–v5) and asserts 200.
* Confirmed the regression: reverted the fix locally against the running dev server — v5 returned 400; restored the fix — same request returned 200 with `cua_version: "v5"` echoed back correctly.
* `pnpm lint` / `pnpm format` — clean, whole repo.
* `pnpm typecheck` — clean, all 11 packages.
* `pnpm security:scan` — clean, 87 client files scanned.
* `pnpm test` — 764/764 passing, whole repo (backend: 159/159, including the new test).
* E2E intentionally not run — confirmed it never exercises this endpoint (`ARCHITECTURE.md` notes E2E deliberately never starts a local run, since it would seize the real mouse).